### PR TITLE
fix: ensure buttons show cursor pointer on hover

### DIFF
--- a/moments/app/globals.css
+++ b/moments/app/globals.css
@@ -119,5 +119,8 @@
   body {
     @apply bg-background text-foreground;
   }
+  button:not([disabled]),
+  [role="button"]:not([disabled]) {
+    cursor: pointer;
+  }
 }
-


### PR DESCRIPTION
### Bug Fix (#26 ): Button Cursor Not Showing Pointer

This PR ensures that all interactive buttons display a `cursor: pointer` when hovered, 
improving UX consistency across the app. This may have been caused by changes in the 
latest Tailwind CSS version defaults.

### Changes Made
- Added a `cursor: pointer` rule for `button:not([disabled])` and `[role="button"]:not([disabled])`
  in `global.css`.

### Before
- Hovering over buttons did not always display the pointer cursor.

### After
- All enabled buttons and elements with `role="button"` now show the pointer cursor on hover.

### Checklist
- [x] Fix applied in `global.css`
- [x] Tested locally to confirm correct hover behavior
