### PR TITLE
feat(ui): Add scale and shadow hover effects to Hero CTA buttons (#95)

### DIFF
--- a/moments/components/landing/HeroSection.tsx
+++ b/moments/components/landing/HeroSection.tsx
@@ -39,7 +39,7 @@ const HeroSection = () => {
             <div className="flex flex-col sm:flex-row justify-center lg:justify-start gap-4 fade-in-up stagger-2">
               <Button
                 size="lg"
-                className="bg-primary hover:bg-primary/90 text-white cursor-pointer w-full sm:w-auto"
+                className="bg-primary hover:bg-primary/90 text-white cursor-pointer w-full sm:w-auto transition-transform duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg"
                 onClick={() => router.push('/new-project')}
               >
                 Start Your Book
@@ -47,7 +47,7 @@ const HeroSection = () => {
               <Button
                 size="lg"
                 variant="outline"
-                className="border-primary text-primary hover:bg-primary/10 cursor-pointer w-full sm:w-auto"
+                className="border-primary text-primary hover:bg-primary/10 cursor-pointer w-full sm:w-auto transition-transform duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg"
               >
                 See Examples
               </Button>


### PR DESCRIPTION
Implements the 'Add hover effects on buttons' suggestion from Issue #95.

This commit adds subtle visual feedback to the main Call-to-Action (CTA) buttons in the HeroSection of the landing page.

The changes include:
- Applying Tailwind CSS classes (`transition-transform`, `duration-300`, `hover:scale-[1.02]`, and `hover:shadow-lg`).
- Ensuring smooth, performance-optimized transitions to improve user engagement and visual appeal, as requested.

Closes #95